### PR TITLE
Add shipping&customerバリデーション修正

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -6,15 +6,11 @@ class Customer < ApplicationRecord
 
   has_many :shipping_addresses, dependent: :destroy
 
-  #with_optionsで共通のバリデーションをまとめる
-  with_options presence: true do |u|
-    u.validates :first_name
-    u.validates :last_name
-    u.validates :first_name_kana
-    u.validates :last_name_kana
-    u.validates :post_code, format: { with: /\A\d{7}\z/} #郵便番号は7桁
-    u.validates :address
-    u.validates :phone_number, format: { with: /\A\d{10,11}\z/} #電話番号は10桁か11桁
-  end
+  validates :last_name, presence: true
+  validates :first_name_kana, presence: true
+  validates :last_name_kana, presence: true
+  validates :post_code, presence: true, format: { with: /\A\d{7}\z/} #郵便番号は7桁
+  validates :address, presence: true
+  validates :phone_number, presence: true, format: { with: /\A\d{10,11}\z/} #電話番号は10桁か11桁
 
 end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,11 +1,8 @@
 class ShippingAddress < ApplicationRecord
   belongs_to :customer
 
-　with_options presence: true do |u|
-    u.validates :customer_id
-    u.validates :post_code, format: { with: /\A\d{7}\z/}
-    u.validates :address
-    u.validates :name
-  end
+  validates :post_code, presence: true, format: { with: /\A\d{7}\z/}
+  validates :address, presence: true
+  validates :name, presence: true
 
 end


### PR DESCRIPTION
変更点
・customersモデル、shipping_addressesモデルのバリデーション
with_options を削除し、一つずつ記載